### PR TITLE
Add Identity provider - htpasswd role

### DIFF
--- a/ansible/playbook/post_installation.yml
+++ b/ansible/playbook/post_installation.yml
@@ -10,7 +10,7 @@
     - { role: 'install_jenkins',      tags: 'jenkins'}
     - { role: 'install_jaeger',       tags: 'jaeger'}
     - { role: 'install_istio',        tags: 'istio',                when: service_mesh | default('false') | bool == true }
-    - { role: 'identity_provider',    tags: 'identity-provider'}
+    - { role: 'identity_provider',    tags: 'identity_provider'}
     
 
 # Unfortunately this can't be a separate role, because the path where the various playbooks are looked up get's messed-up

--- a/ansible/playbook/post_installation.yml
+++ b/ansible/playbook/post_installation.yml
@@ -10,6 +10,7 @@
     - { role: 'install_jenkins',      tags: 'jenkins'}
     - { role: 'install_jaeger',       tags: 'jaeger'}
     - { role: 'install_istio',        tags: 'istio',                when: service_mesh | default('false') | bool == true }
+    - { role: 'identity_provider',    tags: 'identity-provider'}
     
 
 # Unfortunately this can't be a separate role, because the path where the various playbooks are looked up get's messed-up

--- a/ansible/playbook/roles/cluster_up/defaults/main.yml
+++ b/ansible/playbook/roles/cluster_up/defaults/main.yml
@@ -15,7 +15,8 @@ openshift_user: admin
 
 cluster_ip_address: 192.168.99.50
 cluster_use_existing_config: true
-cluster_host_config_dir: /var/lib/openshift/config
+# Switch to docker folder config dir as it uses a different path and not the onde defined for oc cluster up
+cluster_host_config_dir: /var/lib/origin/openshift.local.config
 cluster_host_data_dir: /var/lib/openshift/data
 cluster_host_volumes_dir: /var/lib/openshift/volumes
 cluster_host_pv_dir: /var/lib/openshift/pv

--- a/ansible/playbook/roles/identity_provider/defaults/main.yml
+++ b/ansible/playbook/roles/identity_provider/defaults/main.yml
@@ -1,0 +1,3 @@
+
+cluster_host_config_dir: /var/lib/origin/openshift.local.config
+users_pwd_file: users.htpasswd

--- a/ansible/playbook/roles/identity_provider/tasks/main.yml
+++ b/ansible/playbook/roles/identity_provider/tasks/main.yml
@@ -1,0 +1,25 @@
+-set_fact:
+    path_users_pwd: "{{ cluster_host_config_dir }}/{{ users_pwd_file }}"
+
+- name: Install httpd-tools package if not there
+  yum:
+    name: httpd-tools
+    state: present
+
+- stat: "{{ path_users_pwd }}"
+  register: p
+
+- name: Create users.htpasswd file
+  file: "{{ path_users_pwd }}"
+  when: p.stat.exists is defined and not p.stat.exists
+
+- name: Create user/pwd
+  command: "htpasswd -b {{ path_users_pwd }} {{ item.user }} {{ item.pwd }}"
+  with_dict: with_dict: "{{ users }}"
+
+- name: Patch master-config file to use HTPasswdPasswordIdentityProvider
+  command: oc ex config patch /var/lib/openshift/config/master/master-config.yaml -p '{"oauthConfig":{"identityProviders":[{"challenge":true,"login":true,"mappingMethod":"add","name":"htpassword","provider":{"apiVersion":"v1","kind":"HTPasswdPasswordIdentityProvider","file":"/var/lib/openshift/config/master/users.htpasswd"}}]}}'
+
+- name: Stop/Start docker daemon to reload master-config.yaml
+  command: docker stop origin &> /dev/null && docker start origin &> /dev/null
+

--- a/ansible/playbook/roles/identity_provider/tasks/main.yml
+++ b/ansible/playbook/roles/identity_provider/tasks/main.yml
@@ -30,15 +30,13 @@
   register: patch
 
 - name: Patch master-config file to use HTPasswdPasswordIdentityProvider
-  command: "oc ex config patch {{ cluster_host_config_dir }}/master/master-config.yaml -p '{{ patch.stdout }}'"
+  command: "oc ex config patch {{ cluster_host_config_dir }}/master/master-config.yaml --patch '{{ patch.stdout }}'"
+  register: r
 
-# TODO: check what is needed to -> No module named docker. Try `pip install docker-py`
-# - name: Restart origin container
-#   docker_container:
-#     name: origin
-#     state: started
-#     restart: yes
+- name: Copy patch to new master config file
+  copy: content="{{ r.stdout }}" dest={{ cluster_host_config_dir }}/master/master-config.yaml
 
-- name: Stop origin docker container
-  command: "docker stop origin '> /dev/null'"
+- name: Restart origin container
+  shell: "docker restart origin"
+
 

--- a/ansible/playbook/roles/identity_provider/tasks/main.yml
+++ b/ansible/playbook/roles/identity_provider/tasks/main.yml
@@ -1,4 +1,4 @@
--set_fact:
+- set_fact:
     path_users_pwd: "{{ cluster_host_config_dir }}/{{ users_pwd_file }}"
 
 - name: Install httpd-tools package if not there
@@ -6,20 +6,39 @@
     name: httpd-tools
     state: present
 
-- stat: "{{ path_users_pwd }}"
+- stat:
+    path: "{{ path_users_pwd }}"
   register: p
 
 - name: Create users.htpasswd file
-  file: "{{ path_users_pwd }}"
-  when: p.stat.exists is defined and not p.stat.exists
+  file:
+    path: "{{ path_users_pwd }}"
+    state: touch
+  when: not p.stat.exists
 
 - name: Create user/pwd
-  command: "htpasswd -b {{ path_users_pwd }} {{ item.user }} {{ item.pwd }}"
-  with_dict: with_dict: "{{ users }}"
+  command: "htpasswd -b {{ path_users_pwd }} {{ item.value.user }} {{ item.value.pwd }}"
+  with_dict: "{{ users }}"
+
+- name: Generate patch using template
+  template:
+    src: "{{ role_path }}/templates/htpwd_ip_patch.json.j2"
+    dest: /tmp/htpwd_ip_patch.json
+
+- name: Get patch file
+  command: cat /tmp/htpwd_ip_patch.json
+  register: patch
 
 - name: Patch master-config file to use HTPasswdPasswordIdentityProvider
-  command: oc ex config patch /var/lib/openshift/config/master/master-config.yaml -p '{"oauthConfig":{"identityProviders":[{"challenge":true,"login":true,"mappingMethod":"add","name":"htpassword","provider":{"apiVersion":"v1","kind":"HTPasswdPasswordIdentityProvider","file":"/var/lib/openshift/config/master/users.htpasswd"}}]}}'
+  command: "oc ex config patch {{ cluster_host_config_dir }}/master/master-config.yaml -p '{{ patch.stdout }}'"
 
-- name: Stop/Start docker daemon to reload master-config.yaml
-  command: docker stop origin &> /dev/null && docker start origin &> /dev/null
+# TODO: check what is needed to -> No module named docker. Try `pip install docker-py`
+# - name: Restart origin container
+#   docker_container:
+#     name: origin
+#     state: started
+#     restart: yes
+
+- name: Stop origin docker container
+  command: "docker stop origin '> /dev/null'"
 

--- a/ansible/playbook/roles/identity_provider/templates/htpwd_ip_patch.json.j2
+++ b/ansible/playbook/roles/identity_provider/templates/htpwd_ip_patch.json.j2
@@ -1,0 +1,17 @@
+{
+  "oauthConfig": {
+    "identityProviders": [
+      {
+        "challenge": true,
+        "login": true,
+        "mappingMethod": "add",
+        "name": "htpassword",
+        "provider": {
+          "apiVersion": "v1",
+          "kind": "HTPasswdPasswordIdentityProvider",
+          "file": "{{ cluster_host_config_dir }}/{{ users_pwd_file }}"
+        }
+      }
+    ]
+  }
+}

--- a/ansible/playbook/roles/identity_provider/vars/main.yml
+++ b/ansible/playbook/roles/identity_provider/vars/main.yml
@@ -1,0 +1,7 @@
+users:
+  admin:
+    user: admin
+    pwd: admin
+  guest:
+    user: developer
+    pwd: developer


### PR DESCRIPTION
Add Identity provider - htpasswd role but there are still 2 issues as : 
- We can't stop/ start `origin` docker container
- Even if `oc config exec patch` doesn't report errors, `master-config.yaml` file isn't changed