### PR TITLE
Add first iteration of Openstack support

### DIFF
--- a/ansible/README-openstack.md
+++ b/ansible/README-openstack.md
@@ -1,0 +1,105 @@
+# Install all in one Openshift Origin 3.9 on an Openstack machine
+
+## Provision Machine from Openstack
+
+The first thing that needs to be done is to provision a fairly large CentOS machine from Openstack.
+This can of course be done via the UI or can be automated using the ansible openstack playbook like so:
+
+`ansible-playbook playbook/openstack.yml -e '{"state": "present", "hostname": "somehostname", "openstack": {"os_username": "username", "os_password": "password", "os_auth_url": "https://somehost:13000/v2.0/"}}'`
+
+The playbook also uses the variables defined in `roles/openstack/defaults/main.yml`. Those variables can also be overriden using the syntax above.
+For example to override the VM flavor, one would execute the following command:
+
+`ansible-playbook playbook/openstack.yml -e '{"state": "present", "hostname": "somehostname", "openstack": {"flavor": "m1.medium"", "os_username": "username", "os_password": "password", "os_auth_url": "https://somehost:13000/v2.0/"}}'`
+
+To delete a VM, simply replace `"state": "present"` with `"state": "absent"`
+
+## Update the created VM so Openshift can be installed on it
+
+After ssh-ing into the machine the following changes need to be made:
+
+* Disable selinux
+  
+  selinux can be disabled by setting `SELINUX=disabled` in `/etc/selinux/config`
+  
+* Install network manager
+
+  `sudo yum install -y NetworkManager`
+  
+* Restart VM
+  
+  This can easily be done by the Openstack UI using `Soft Reboot Instance`
+  
+## Execute openshift-ansible playbooks
+
+Assuming floating IP = `10.8.250.104` and private IP = `172.16.195.12` an inventory file named `inventory/openstack_host` needs to be created like so:
+
+```plain
+[OSEv3:children]
+masters
+nodes
+etcd
+
+[OSEv3:vars]
+ansible_user=centos
+
+public_ip_address=10.8.250.104
+host_key_checking=false
+
+containerized=true
+openshift_enable_excluders=false
+openshift_release=v3.9
+
+openshift_deployment_type=origin
+
+openshift_hostname=n002
+openshift_master_cluster_public_hostname=10.8.250.104
+openshift_master_default_subdomain=10.8.250.104.nip.io
+openshift_master_unsupported_embedded_etcd=true
+
+# To avoid message
+# - Available disk space in "/var" (9.5 GB) is below minimum recommended (40.0 GB)
+# - Docker storage drivers 'overlay' and 'overlay2' are only supported with 'xfs' as the backing storage, but this host's storage is type 'extfs'
+# - Available memory (2.0 GiB) is too far below recommended value (16.0 GiB)
+# - Docker version is higher than expected
+openshift_disable_check = docker_storage,memory_availability,disk_availability,docker_image_availability,package_version
+
+# we need to increase the pods per core because we might temporarily have multiple build pods running at the same time
+openshift_node_kubelet_args={'pods-per-core': ['20']}
+
+# ASB Service Catalog
+openshift_enable_service_catalog=false
+ansible_service_broker_registry_whitelist=[".*-apb$"]
+
+# Python Interpreter
+ansible_python_interpreter=/usr/bin/python
+
+# Enable htpasswd auth
+openshift_master_identity_providers=[{'name': 'htpasswd_auth', 'login': 'true', 'challenge': 'true', 'kind': 'HTPasswdPasswordIdentityProvider', 'filename': '/etc/origin/master/htpasswd'}]
+# htpasswd -nb admin admin
+openshift_master_htpasswd_users={'admin': '$apr1$DloeoaY3$nqbN9fQBkyXgbj58buqEM.'}
+
+
+
+# host group for masters
+[masters]
+10.8.250.104 openshift_public_hostname=10.8.250.104 openshift_hostname=172.16.195.12
+
+[etcd]
+10.8.250.104
+
+# host group for worker nodes, we list master node here so that
+# openshift-sdn gets installed. We mark the master node as not
+# schedulable.
+[nodes]
+10.8.250.104 openshift_node_labels="{'region':'infra','zone':'default', 'node-role.kubernetes.io/compute': 'true'}" openshift_public_hostname=10.8.250.104 openshift_hostname=172.16.195.12
+```
+
+The openshift-ansible playbooks can now be launched like so:
+
+
+```bash
+ansible-playbook -i inventory/cloud_host_n002 openshift-ansible/playbooks/prerequisites.yml --become
+ansible-playbook -i inventory/cloud_host_n002 openshift-ansible/playbooks/deploy-playbook.yml --become
+```  
+

--- a/ansible/playbook/openstack.yml
+++ b/ansible/playbook/openstack.yml
@@ -1,0 +1,5 @@
+- hosts: localhost
+  gather_facts: False
+
+  roles:
+    - { role: openstack }

--- a/ansible/playbook/roles/openstack/defaults/main.yml
+++ b/ansible/playbook/roles/openstack/defaults/main.yml
@@ -1,0 +1,16 @@
+hostname: openstackVM
+
+openstack:
+  os_region_name: regionOne
+  os_project_name: spring-boot-jenkins
+  sshkey_name: "{{ hostname }}"
+
+  vm:
+    title: CentOS 7 Generic Cloud Latest
+    name: "{{ hostname }}"
+    image: CentOS-7-x86_64-GenericCloud-released-latest
+    key_name: "{{ hostname }}"
+    flavor: m1.xlarge
+    auto_floating_ip: yes
+    network: spring-boot-jenkins-priv-network
+    security_group: spring-boot-osoos

--- a/ansible/playbook/roles/openstack/tasks/keys.yml
+++ b/ansible/playbook/roles/openstack/tasks/keys.yml
@@ -1,0 +1,26 @@
+- name: Find admin user home folder
+  local_action: shell echo "{{ lookup('env','HOME') }}"
+  register: admin_home
+
+- name: Set admin ssh key path
+  set_fact: key_path="{{ admin_home.stdout }}/.ssh/id_openstack.rsa"
+  no_log: True
+
+- stat:
+    path: "{{ key_path }}"
+  register: st
+
+- name: Generate SSH keys
+  shell: ssh-keygen -b 2048 -t rsa -f {{ key_path }} -q -N ""
+  when: st.stat.exists == false
+
+- name: Create SSH key to use with instances
+  os_keypair:
+    state: present
+    auth:
+      project_name: "{{ openstack.os_project_name }}"
+      username: "{{ openstack.os_username }}"
+      password: "{{ openstack.os_password }}"
+      auth_url: "{{ openstack.os_auth_url }}"
+    name: "{{ openstack.sshkey_name }}"
+    public_key_file: "{{ key_path }}.pub"

--- a/ansible/playbook/roles/openstack/tasks/main.yml
+++ b/ansible/playbook/roles/openstack/tasks/main.yml
@@ -1,0 +1,53 @@
+---
+
+- name: Generate keys locally and import the pub key into Openstack
+  include_tasks: keys.yml
+  when: state == "present"
+
+- name: "{{ 'Create' if state == \"present\" else 'Delete' }} {{ openstack.vm.name }} - {{ openstack.vm.title }}"
+  os_server:
+    state: "{{ state }}"
+    auth:
+      project_name: "{{ openstack.os_project_name }}"
+      username: "{{ openstack.os_username }}"
+      password: "{{ openstack.os_password }}"
+      auth_url: "{{ openstack.os_auth_url }}"
+    name: "{{ openstack.vm.name }}"
+    image: "{{ openstack.vm.image }}"
+    key_name: "{{ openstack.vm.key_name }}"
+    timeout: 200
+    flavor: "{{ openstack.vm.flavor }}"
+    auto_floating_ip: yes
+    network: "{{ openstack.vm.network }}"
+    security_groups: "{{ openstack.vm.security_group }}"
+  register: openstack_output
+
+- name: Delete key {{ openstack.sshkey_name }} from server
+  os_keypair:
+    state: absent
+    auth:
+      project_name: "{{ openstack.os_project_name }}"
+      username: "{{ openstack.os_username }}"
+      password: "{{ openstack.os_password }}"
+      auth_url: "{{ openstack.os_auth_url }}"
+    name: "{{ openstack.sshkey_name }}"
+  when: state == "absent"
+
+- name: Print Openstack output
+  debug:
+    var: openstack_output
+
+- block:
+
+  - name: Show IP addresses
+    debug:
+      msg: "VM Public IP : {{ openstack_output.server.accessIPv4 }} / VM Private IP: {{ openstack_output.server.private_v4 }}"
+
+
+  - name: Show useful ssh login info
+    debug:
+      msg:
+        - "You can ssh into the newly created VM using the following command:"
+        - "ssh -i {{ key_path }} centos@{{ openstack_output.server.accessIPv4 }}"
+
+  when: state == "present"


### PR DESCRIPTION
This is a first iteration that contains the basic playbook to provision an Openstack VM and instructions on how to install Openshift on it.

Future work needs to replace the manual steps with various playbooks in order for complete automation to work