### PR TITLE
Remove symbolic link

### DIFF
--- a/ansible/playbook/roles/cluster/tasks/main.yml
+++ b/ansible/playbook/roles/cluster/tasks/main.yml
@@ -42,10 +42,6 @@
 - name: Cluster up
   include_tasks: cluster_up.yml
 
-- name: Create a symbolic link between folders of OpenShift and /etc/origin as this one is used by the openshift ansible playbook to access master.yml config file
-  command: ln -s /var/lib/origin/openshift.local.config /etc/origin
-  ignore_errors: yes
-
 - name: Show cluster up output
   debug:
     var: clusterupout.stdout_lines


### PR DESCRIPTION
This link should not be needed since the playbooks can now infer their
environment and using the /etc/origin directory for configuration is not
necessary - actually it can hurt